### PR TITLE
added macro to make eurotherm units work

### DIFF
--- a/ReadASCIIApp/Db/get_metadata.db
+++ b/ReadASCIIApp/Db/get_metadata.db
@@ -4,6 +4,7 @@
 # CAL - the calibration file readback PV
 # OUT - the PV to write the metadata to.
 # OUTF - the PV field to write the metadata to (defaults to VAL)
+# OUTPP -  NP by default, eurotherm needs PP for corect units 
 # NAME - the name in the json of the piece of metadata to extract
 # DEFAULT - if metadata could not be extracted or was not present
 #
@@ -44,6 +45,6 @@ record(aSub, "$(OUT):_UNITS")
     field(INPE, "$(OUT):$(OUTF=VAL):_META:DEF CP")
     field(FTE, "STRING")
       
-    field(OUTA, "$(OUT).$(OUTF=VAL)")
+    field(OUTA, "$(OUT).$(OUTF=VAL) $(OUTPP=NP)")
     field(FTVA, "STRING")
 }

--- a/ReadASCIIApp/Db/get_metadata.db
+++ b/ReadASCIIApp/Db/get_metadata.db
@@ -4,7 +4,7 @@
 # CAL - the calibration file readback PV
 # OUT - the PV to write the metadata to.
 # OUTF - the PV field to write the metadata to (defaults to VAL)
-# OUTPP -  NP by default, eurotherm needs PP for corect units 
+# OUTPP -  NP by default, eurotherm needs PP for corect units
 # NAME - the name in the json of the piece of metadata to extract
 # DEFAULT - if metadata could not be extracted or was not present
 #
@@ -24,27 +24,27 @@ record(aSub, "$(OUT):_UNITS")
     field(DESC, "Gets units based on calibration file")
 
     field(SNAM, "get_calib_metadata")
-	
+
     # Base dir
     field(INPA, "$(DIR).BDIR CP")
     field(FTA, "STRING")
-	
+
     # Sensor dir
 	field(INPB, "$(DIR).TDIR CP")
 	field(FTB, "STRING")
-	
+
     # Sensor file
     field(INPC, "$(CAL) CP")
     field(FTC, "STRING")
-	
+
     # Property name to read from JSON
     field(INPD, "$(OUT):$(OUTF=VAL):_META:NAM CP")
     field(FTD, "STRING")
-	
+
     # Default value
     field(INPE, "$(OUT):$(OUTF=VAL):_META:DEF CP")
     field(FTE, "STRING")
-      
-    field(OUTA, "$(OUT).$(OUTF=VAL) $(OUTPP=NP)")
+
+    field(OUTA, "$(OUT).$(OUTF=VAL) $(OUTPP=NPP)")
     field(FTVA, "STRING")
 }


### PR DESCRIPTION
Eurotherm units need PP to work properly, so a macro to set a default of NP was added so that nothing was written/overwritten on the instrument due to an automatic PP in the wrong place