### PR TITLE
Ticket 6350: Add flag to make quieter

### DIFF
--- a/ReadASCIIApp/src/ReadASCII.h
+++ b/ReadASCIIApp/src/ReadASCII.h
@@ -12,7 +12,7 @@
 class ReadASCII : public asynPortDriver 
 {
 public:
-    ReadASCII(const char* portName, const char *searchDir, const int stepsPerMinute);
+    ReadASCII(const char* portName, const char *searchDir, const int stepsPerMinute, const bool logOnSetPoint);
 
 
     virtual asynStatus writeOctet(asynUser *pasynUser, const char *value, size_t maxChars, size_t *nActual);
@@ -71,6 +71,7 @@ private:
     int getSPInd (double SP);
     void updatePID(int index);
     asynStatus readFileBasedOnParameters();
+    bool quietOnSetPoint;
     
 #define FIRST_READASCII_PARAM P_Dir
 #define LAST_READASCII_PARAM P_MaxHeat


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/6350

To test:
* Pull and build
* Run up an IOC that uses ReadASCII e.g. `%PYTHON3% run_tests.py -t kepco_rem -a -tm DEVSIM`
* Write to the set point PV e.g. `caput %MYPVPREFIX%KEPCO_01:CURRENT:SP 20`
* Confirm that with no changes to the st.cmd the above logs in the IOC log
* Repeat but with the changes in https://github.com/ISISComputingGroup/EPICS-ioc/pull/607 and confirm that it does not print