### PR TITLE
Ticket 4735

### DIFF
--- a/ReadASCIIApp/src/ReadASCII.cpp
+++ b/ReadASCIIApp/src/ReadASCII.cpp
@@ -61,6 +61,7 @@ ReadASCII::ReadASCII(const char *portName, const char *searchDir, const int step
     addParameter(P_RampingString, asynParamInt32, &P_Ramping);
     addParameter(P_RampOnString, asynParamInt32, &P_RampOn);
     addParameter(P_LookUpOnString, asynParamInt32, &P_LookUpOn);
+	addParameter(P_LookUpTableChangedString, asynParamInt32, &P_LookUpTableChanged);
 
     addParameter(P_TargetString, asynParamFloat64, &P_Target);
     addParameter(P_SPRBVString, asynParamFloat64, &P_SPRBV);
@@ -71,18 +72,21 @@ ReadASCII::ReadASCII(const char *portName, const char *searchDir, const int step
     addParameter(P_SPOutString, asynParamFloat64);
 
     //Init
-    setStringParam(P_Dir, "Default.txt");
+    setStringParam(P_Dir, DEFAULT_RAMP_FILE);
+	setIntegerParam(P_LookUpTableChanged, 0);
     setStringParam(P_DirBase, searchDir);
     fileBad = true;
     rowNum = 0;
     lastModified = 0;
     quietOnSetPoint = setQuietOnSetPoint;
+	
 
     setDoubleParam(P_RampRate, 1.0);
     setDoubleParam(P_StepsPerMin, stepsPerMinute);
     setIntegerParam(P_Ramping, 0);
     setIntegerParam(P_RampOn, 0);
     setIntegerParam(P_LookUpOn, 0);
+	
 
     //Try to read file once to load parameters
     readFileBasedOnParameters();
@@ -125,7 +129,6 @@ ReadASCII::ReadASCII()
 {
 }
 
-
 asynStatus ReadASCII::drvUserCreate(asynUser* pasynUser, const char* drvInfo, const char** pptypeName, size_t* psize)
 {
     if (!dynamicParameters)
@@ -160,6 +163,7 @@ asynStatus ReadASCII::writeOctet(asynUser *pasynUser, const char *value, size_t 
     int status = asynSuccess;
     const char *paramName;
     const char* functionName = "writeOctet";
+	char localDir[DIR_LENGTH];
 
     /* Set the parameter in the parameter library. */
     status = (asynStatus)setStringParam(function, value);
@@ -170,6 +174,15 @@ asynStatus ReadASCII::writeOctet(asynUser *pasynUser, const char *value, size_t 
     if (function == P_Dir || function == P_DirBase) {
         // Directory has changed so update
         status |= readFileBasedOnParameters();
+		
+		// If directory has changed (and not to default) then update
+		getStringParam(P_Dir, DIR_LENGTH, localDir);
+		if(strncmp(DEFAULT_RAMP_FILE, localDir, DIR_LENGTH) == 0){
+			setIntegerParam(P_LookUpTableChanged, 0);
+		} else {
+			setIntegerParam(P_LookUpTableChanged, 1);
+		}
+		
     }
 
     /* Do callbacks so higher layers see any changes */

--- a/ReadASCIIApp/src/ReadASCII.cpp
+++ b/ReadASCIIApp/src/ReadASCII.cpp
@@ -61,7 +61,7 @@ ReadASCII::ReadASCII(const char *portName, const char *searchDir, const int step
     addParameter(P_RampingString, asynParamInt32, &P_Ramping);
     addParameter(P_RampOnString, asynParamInt32, &P_RampOn);
     addParameter(P_LookUpOnString, asynParamInt32, &P_LookUpOn);
-	addParameter(P_LookUpTableChangedString, asynParamInt32, &P_LookUpTableChanged);
+	addParameter(P_LookUpTableNotDefaultString, asynParamInt32, &P_LookUpTableNotDefault);
 
     addParameter(P_TargetString, asynParamFloat64, &P_Target);
     addParameter(P_SPRBVString, asynParamFloat64, &P_SPRBV);
@@ -73,7 +73,7 @@ ReadASCII::ReadASCII(const char *portName, const char *searchDir, const int step
 
     //Init
     setStringParam(P_Dir, DEFAULT_RAMP_FILE);
-	setIntegerParam(P_LookUpTableChanged, 0);
+	setIntegerParam(P_LookUpTableNotDefault, 0);
     setStringParam(P_DirBase, searchDir);
     fileBad = true;
     rowNum = 0;
@@ -178,9 +178,9 @@ asynStatus ReadASCII::writeOctet(asynUser *pasynUser, const char *value, size_t 
 		// If directory has changed (and not to default) then update
 		getStringParam(P_Dir, DIR_LENGTH, localDir);
 		if(strncmp(DEFAULT_RAMP_FILE, localDir, DIR_LENGTH) == 0){
-			setIntegerParam(P_LookUpTableChanged, 0);
+			setIntegerParam(P_LookUpTableNotDefault, 0);
 		} else {
-			setIntegerParam(P_LookUpTableChanged, 1);
+			setIntegerParam(P_LookUpTableNotDefault, 1);
 		}
 		
     }

--- a/ReadASCIIApp/src/ReadASCII.h
+++ b/ReadASCIIApp/src/ReadASCII.h
@@ -37,7 +37,7 @@ protected:
     int P_Ramping; //int
     int P_RampOn; //int
     int P_LookUpOn; //int
-	int P_LookUpTableChanged; //int
+	int P_LookUpTableNotDefault; //int
 
     int P_RampRate; //float
     int P_StepsPerMin; //float
@@ -119,7 +119,7 @@ private:
 #define P_RampingString "CURRMP"
 #define P_RampOnString "RMP"
 #define P_LookUpOnString "LUT"
-#define P_LookUpTableChangedString "LUTCG"
+#define P_LookUpTableNotDefaultString "LUTNDF"
 
 
 #define P_TargetString "TGT"

--- a/ReadASCIIApp/src/ReadASCII.h
+++ b/ReadASCIIApp/src/ReadASCII.h
@@ -8,6 +8,7 @@
 #include "asynPortDriver.h"
 
 #define DIR_LENGTH 260
+#define DEFAULT_RAMP_FILE "Default.txt"
 
 class ReadASCIITest;
 
@@ -36,6 +37,7 @@ protected:
     int P_Ramping; //int
     int P_RampOn; //int
     int P_LookUpOn; //int
+	int P_LookUpTableChanged; //int
 
     int P_RampRate; //float
     int P_StepsPerMin; //float
@@ -117,6 +119,8 @@ private:
 #define P_RampingString "CURRMP"
 #define P_RampOnString "RMP"
 #define P_LookUpOnString "LUT"
+#define P_LookUpTableChangedString "LUTCG"
+
 
 #define P_TargetString "TGT"
 #define P_SPRBVString "TGT:RBV"
@@ -125,4 +129,5 @@ private:
 #define P_CurTempString "CUR"
 
 #define P_SPOutString "SP"
+
 #endif /* READASCII_H */

--- a/ReadASCIITestApp/Db/ReadASCII.db
+++ b/ReadASCIITestApp/Db/ReadASCII.db
@@ -26,10 +26,10 @@ record(stringin, "$(P)RAMP_FILE")
    field(SCAN, "I/O Intr")
 }
 
-record(longin, "$(P)RAMP_FILE_CHANGED")
+record(longin, "$(P)RAMP_FILE_NOT_DEFAULT")
 {
     field(DTYP, "asynInt32")
-    field(INP,  "@asyn($(READ),0,1)LUTCG")
+    field(INP,  "@asyn($(READ),0,1)LUTNDF")
     field(SCAN, "I/O Intr")
 }
 

--- a/ReadASCIITestApp/Db/ReadASCII.db
+++ b/ReadASCIITestApp/Db/ReadASCII.db
@@ -26,6 +26,13 @@ record(stringin, "$(P)RAMP_FILE")
    field(SCAN, "I/O Intr")
 }
 
+record(longin, "$(P)RAMP_FILE_CHANGED")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(READ),0,1)LUTCG")
+    field(SCAN, "I/O Intr")
+}
+
 record(stringout, "$(P)RAMP_FILE:SP")
 {
    field(DTYP, "asynOctetWrite")


### PR DESCRIPTION
- Added new `RAMP_FILE_NOT_DEFAULT` PV to the readascii db.
- Added default ramp file macro `DEFAULT_RAMP_FILE` for consistency.
- Updated `writeOctet `fn to also update `RAMP_FILE_NOT_DEFAULT` PV when the DIP and max output lookup file is changed from the default file. 
